### PR TITLE
Rename "Threads" to "workers" 

### DIFF
--- a/mapping/mapping.go
+++ b/mapping/mapping.go
@@ -16,28 +16,28 @@ type Sequencer func(chan<- Copyable)
 // Transformer from a Copyable to a new thing
 type Transformer func(Copyable) interface{}
 
-// DefaultThreads for distributing tasks
-const DefaultThreads = 128
+// DefaultConcurrentWorkers for distributing tasks
+const DefaultConcurrentWorkers = 128
 
 // ForEach thing in input apply f and put it in out but unlike Map order is not preserved
 // Closes out when complete
 func ForEach(in Sequencer, out chan<- interface{}, f Transformer) {
-	ForEachN(in, out, f, DefaultThreads)
+	ForEachN(in, out, f, DefaultConcurrentWorkers)
 }
 
 // ForEachN thing in input apply f and put it in out but unlike Map order is not preserved
 // runs with a pool of N instead of the default, Closes out when complete
-func ForEachN(in Sequencer, out chan<- interface{}, f Transformer, threads int) {
-	if threads < 1 {
-		threads = 1
+func ForEachN(in Sequencer, out chan<- interface{}, f Transformer, numWorkers int) {
+	if numWorkers < 1 {
+		numWorkers = 1
 	}
-	if threads > 1024 {
-		threads = 1024
+	if numWorkers > 1024 {
+		numWorkers = 1024
 	}
 	wg := &sync.WaitGroup{}
 	c := make(chan Copyable, 1024)
 	go in(c)
-	for i := 0 ; i < threads ; i++ {
+	for i := 0 ; i < numWorkers ; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
Make it clear that goroutines not literal threads.